### PR TITLE
Fix buffer connection text parameter error

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ def send_automated_daily_promo():
         
         # Send to Make.com webhook
         payload = {
-            "promoText": promo,
+            "text": promo,
             "videoURL": video_url,
             "imageURL": image_url,
             "videoTitle": f"EspaLuz Success Story: {story['emotion']}",
@@ -271,7 +271,7 @@ def send_daily_promo(message):
 
     try:
         payload = {
-            "promoText": promo,
+            "text": promo,
             "videoURL": video_url,
             "imageURL": image_url,
             "videoTitle": f"EspaLuz Success Story: {story['emotion']}",


### PR DESCRIPTION
Fix `make.com` scenario failure by changing webhook payload parameter from `promoText` to `text`.

---
<a href="https://cursor.com/background-agent?bcId=bc-af6fa258-3332-42f9-bef5-7156287ba3b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af6fa258-3332-42f9-bef5-7156287ba3b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

